### PR TITLE
Update predict.py

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "github.copilot"
+    ]
+}

--- a/predict.py
+++ b/predict.py
@@ -87,5 +87,15 @@ def main(argv):
 
 
 if __name__ == '__main__':
-    tf.logging.set_verbosity(tf.logging.INFO)
-    tf.app.run(main=main)
+
+# Create a SummaryWriter
+writer = tf.summary.create_file_writer("logs")
+def main(argv=None):
+
+  # Run the main function and log the return value
+  result = main()
+
+  # Write the result to the SummaryWriter
+  with writer.as_default():
+    tf.summary.scalar("result", result, step=1)
+


### PR DESCRIPTION
The logging module was removed in TensorFlow 2.0.

To log messages in TensorFlow 2.0 and later, we use Python's built-in logging module or the TensorFlow Summary API. In this case we used TensorFlow Summary API.